### PR TITLE
Install NASM under Windows runners

### DIFF
--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -75,6 +75,11 @@ jobs:
               with:
                 tool: cargo-nextest
 
+            # On Windows, we'll also need nasm for use with BoringSSL via aws-lc-sys.
+            - name: Install NASM
+              uses: ilammy/setup-nasm@v1
+              if: matrix.runner == 'windows-latest'
+
             - name: Pull dependencies
               run: cargo build --workspace --all-features
 


### PR DESCRIPTION
This PR is to test what dependencies are needed to support the vendored copy of BoringSSL within `aws-lc-sys`.